### PR TITLE
Introducing  osm manager process  aka 'osmon'   handler osm service  and more  <This is just a Simple Proposal> 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,31 +4,50 @@
 FROM python:3.12-alpine
 
 # Install only required dependencies and Ensure setuptools is installed before installing dependencies
-RUN apk add --no-cache sqlite-dev figlet py3-setuptools gcc musl-dev python3-dev libffi-dev su-exec && pip install --no-cache-dir --upgrade pip setuptools wheel 
+RUN apk add --no-cache sqlite-dev figlet py3-setuptools gcc meson musl-dev python3-dev libffi-dev su-exec && pip install --no-cache-dir --upgrade pip setuptools wheel 
 
 # Create a non-root user & group for security
 RUN addgroup -S osm && adduser -S osm -G osm
+ 
+
+COPY context/profile   /home/osm/.profile
+ENV  ENV=/home/osm/.profile
+
+COPY osm.py    /usr/local/bin/osm  
+COPY config/osmconf.cfg   /etc/osm/osmconf.cfg
 
 # Set working directory
 WORKDIR /app
 
 # Copy application files
-COPY osm.py requirements.txt entrypoint.sh ./ 
+COPY meson.build requirements.txt entrypoint.sh   ./ 
+COPY src ./src 
 
 # Create a directory for the SQLite database
-RUN mkdir -p /data && chown -R osm:osm /data
+RUN mkdir -p /data && chown -R osm:osm /data 
+
+# BUILDING
+#---------
+# Compile C sources files 
+RUN  meson setup build  && meson compile -C build 
+# Install  bin 
+RUN  meson install -C build  
 
 # Set the correct permissions for the /app directory & Install Python dependencies securely
-RUN  chown -R osm:osm /app && chmod -R 775 /app && pip install --no-cache-dir -r requirements.txt && rm -rf /root/.cache/pip
+RUN  chown -R osm:osm ./ && chmod -R 775 ./ && pip install --no-cache-dir -r requirements.txt && rm -rf /root/.cache/pip
 
+RUN chown -R osm:osm /etc/osm
+# SET X MODE 
+#---------- 
 # Ensure the entrypoint script is executable
-RUN chmod +x /app/entrypoint.sh
+RUN chmod +x ./entrypoint.sh
+RUN chmod +x  /usr/local/bin/osm
 
 # Switch to non-root user
-USER osm
+USER osm  
 
 # # Define entrypoint
 # ENTRYPOINT ["/app/entrypoint.sh"]
 
-# Run the application
-CMD ["python", "osm.py"]
+# Run the Osm  manager that handle the osm application
+CMD ["osmon"]

--- a/config/osmconf.cfg
+++ b/config/osmconf.cfg
@@ -1,0 +1,22 @@
+;default configuration :^)
+;use # or ; to make comment  
+DB_FILE=/data/osm.db
+# Thresholds (%)
+CPU_THRESHOLD=90
+RAM_THRESHOLD=90 
+DISK_THRESHOLD=90
+
+# Interval scheduling
+CHECK_INTERVAL=1 
+
+# Accept "s", "m", "h" for seconds, minutes, hours
+CHECK_INTERVAL_UNIT=m
+SLACK_WEBHOOK_URL=
+ALERT_EMAIL=alerts@example.com 
+SMTP_SERVER=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=user@example.com
+SMTP_PASS=secret
+ALERT_CHANNELS=SLACK,EMAIL
+HOSTNAME=YOUR_SERVER_NAME
+LOG_LEVEL=INFO

--- a/context/profile
+++ b/context/profile
@@ -1,0 +1,19 @@
+export PATH="/app/bin:/app/service:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+export PAGER=less
+umask 022
+
+HNAME=osm
+
+for script in /etc/profile.d/*.sh ; do
+          if [ -r "$script"  ] ; then
+            . "$script"
+            fi
+            done
+unset script
+unset PS1 
+
+PS1="\[\e[34m\]${HNAME}\[\e[m\]@\[\e[33m\]\w\[\e[m\]"
+test [ "$(id -u)" -eq 0 ] && PS1="${PS1}# " || PS1="${PS1}\$ "
+reset
+clear 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       ALERT_CHANNELS: "SLACK,EMAIL"
     volumes:
       - osm_data:/data
+      - ./osm_config:/etc/osm/
       # read-only /proc mount for host-level monitoring
       - /proc:/host_proc:ro
     restart: unless-stopped

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,56 @@
+# Copyright(c) 2025  AGPL-3.0 License -  Umar Ba <jUmarB@protonmail.com> github.com/Jukoo
+# /!\ Should be compiled inside container /!\
+# -------------------------------------------------------
+project('osmon', 'c',
+  version : '0.1',
+  license:['AGPL-3.0-only'],
+  default_options : [
+    'c_std=gnu99',
+    'warning_level=3', 
+    'bindir=/usr/local/bin', 
+    'datadir=/data'])
+
+# - Quick Summay where the essentials files are stored 
+summary({
+'config   ->': '/etc/osm',
+'data     ->': get_option('datadir'),
+'osmon bins ->': get_option('bindir'),
+}, section: 'Osm  Dispatching  Summary')
+
+
+pkg =import('pkgconfig')
+cc = meson.get_compiler('c') 
+
+add_project_arguments(
+  cc.get_supported_arguments([
+    '-Wcomment',
+    '-Wformat',
+    '-Wunused-parameter',
+    '-Wreturn-type',
+    '-Wpedantic',
+    '-Wparentheses',
+    '-Wmissing-braces'
+    ]), 
+  # - TODO | NOTE: Should be intergrate in special config file 
+  # - The NO_BLOCKING_MODE  is disabled by default. Set 1 to enable it 
+  '-DNO_BLOCKING_MODE=0',
+  # - ALLOW OR NOT OVERRIDING EXISTING ENV VARS
+  # - BY DEFAULT IS NOT ENABLE CAUZ THE PRIORITY GOES FOR docker-compose.yml  
+  '-DALLOW_OVERIDE_ENVAR=0',
+  language:'c'
+  )
+
+sources =[
+  'src/osmanager.c',
+  'src/osminitdb.h',
+  'src/config_parser.h'
+  ]
+
+# - Integrate Sqlite3 dev level  
+libsqlite_v3 = dependency('sqlite3')
+
+executable(meson.project_name(),
+  sources,
+  dependencies:libsqlite_v3,
+  install : true,
+  install_dir:get_option('bindir')) 

--- a/osm.py
+++ b/osm.py
@@ -36,29 +36,20 @@ import time
 # ─────────────────────────────────────────────────────────────────────────────
 # 1) ENVIRONMENT CONFIGURATION
 # ─────────────────────────────────────────────────────────────────────────────
-
-DB_FILE = os.getenv("DB_FILE", "osm.db")  # SQLite DB file
-
-# Thresholds (%)
-CPU_THRESHOLD = int(os.getenv("CPU_THRESHOLD", "90"))
-RAM_THRESHOLD = int(os.getenv("RAM_THRESHOLD", "90"))
-DISK_THRESHOLD = int(os.getenv("DISK_THRESHOLD", "90"))
-
-# Interval scheduling
-CHECK_INTERVAL = int(os.getenv("CHECK_INTERVAL", "1"))
-CHECK_INTERVAL_UNIT = os.getenv("CHECK_INTERVAL_UNIT", "m").lower()
-# Accept "s", "m", "h" for seconds, minutes, hours
-
-SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL", "")
-ALERT_EMAIL = os.getenv(
-    "ALERT_EMAIL", "alerts@example.com").replace(" ", "").split(',')
-SMTP_SERVER = os.getenv("SMTP_SERVER", "smtp.example.com")
-SMTP_PORT = int(os.getenv("SMTP_PORT", "587"))
-SMTP_USER = os.getenv("SMTP_USER", "user@example.com")
-SMTP_PASS = os.getenv("SMTP_PASS", "secret")
-ALERT_CHANNELS = os.getenv(
-    "ALERT_CHANNELS", "SLACK,EMAIL")  # e.g. "SLACK,EMAIL"
-HOSTNAME = os.getenv("YOUR_SERVER_NAME", "SamaServerBouNeikhBi")
+ 
+#Notice:  Transforming all environment variables to be manipulated as simple and single variable directly
+class GloblalEnvProperties : 
+    def __init__(self) : 
+        for key_property, val_property in  os.environ.items(): 
+            try : 
+                val_property = int(val_property) 
+            except ValueError: 
+                val_property = val_property
+            
+            setattr(self, key_property,val_property) 
+   
+sys.modules["Osmprops"] = GloblalEnvProperties() 
+from  Osmprops import *  
 
 # Docker host /proc mount path
 HOST_PROC_PATH = "/host_proc"
@@ -75,8 +66,13 @@ sqlite3.register_converter(
 # ─────────────────────────────────────────────────────────────────────────────
 # 2) LOGGING CONFIGURATION (LOGURU)
 # ─────────────────────────────────────────────────────────────────────────────
+try : 
+    OSM_PID 
+except NameError: 
+    OSM_PID="" 
 
-LOG_FORMAT = "<b><magenta>⪢OSM⪡</magenta></b> • <green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level}</level> | <cyan>{message}</cyan>\n"
+LOG_FORMAT = "<i>[" + str(OSM_PID) +"]</i> <b><magenta>⪢OSM⪡</magenta></b> • <green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level}</level> | <cyan>{message}</cyan>\n" 
+
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 
 # Remove default handler
@@ -108,33 +104,6 @@ def print_ascii_banner():
     banner = figlet_format("OrbitSimpleMonitor", font="slant")
     logger.info("\n" + banner + "🚀 Welcome to Orbit Simple Monitor (OSM)!\n")
 
-
-# ─────────────────────────────────────────────────────────────────────────────
-# 4) INIT SQLITE DB
-# ─────────────────────────────────────────────────────────────────────────────
-def init_db(conn=None):
-    """Initializes the SQLite database and creates required tables."""
-    # Check if DB already exists
-    if os.path.exists(DB_FILE):
-        logger.info(f"🗄 Existing DB file '{DB_FILE}' detected. Reusing it.")
-    else:
-        logger.info(f"💾 No DB file '{DB_FILE}' found. Creating a new one...")
-
-    if conn is None:
-        conn = sqlite3.connect(DB_FILE, detect_types=sqlite3.PARSE_DECLTYPES)
-
-    with conn:
-        cursor = conn.cursor()
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS usage_history (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                timestamp DATETIME NOT NULL,
-                cpu_usage REAL NOT NULL,
-                ram_usage REAL NOT NULL,
-                disk_usage REAL NOT NULL
-            )
-        """)
-        conn.commit()
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -285,11 +254,9 @@ def handle_signal(signum, frame):
     logger.warning(f"👋 Caught signal {signum}, shutting down gracefully...")
     sys.exit(0)
 
-
-def main():
+def main(): 
     print_ascii_banner()
     logger.info("🎉 Initializing Orbit Simple Monitor database...")
-    init_db()
 
     schedule_collections()
     logger.info("⏱  Scheduling daily cleanup at 00:00.")
@@ -297,7 +264,7 @@ def main():
 
     logger.info("🚀 Orbit Simple Monitor started. Monitoring your host now...")
 
-    # Catch SIGINT (Ctrl+C) and SIGTERM
+    # Catch SIGINT (Ctrl+C) and SIGTERM  (kill  pid)  
     signal.signal(signal.SIGINT, handle_signal)
     signal.signal(signal.SIGTERM, handle_signal)
 

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -1,0 +1,104 @@
+/* @file config_parser.h 
+ * @brief  basic configuration parse
+ * @copyright(c) 2025  AGPL-3.0 License -  Umar Ba <jUmarB@protonmail.com> github.com/Jukoo  
+ */
+#if !defined (__osm_parseconfig_h )
+#define  __osm_parseconfig_h 
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h> 
+#include <fcntl.h> 
+#include <string.h> 
+
+#define  __assign_symbole  "=" 
+
+#if defined(ALLOW_OVERIDE_ENVAR) && ALLOW_OVERIDE_ENVAR  
+# define  SHOULD_BE_OVERIDED  1 
+#else  
+# define  SHOULD_BE_OVERIDED  0 
+#endif 
+
+#define IS_EMPTY(__eline)(\
+    (strlen(__eline) == 1)&&\
+    ((0xa ==  *(eachline))& 0xff)\
+    )
+
+#define IS_COMMENT(__eline) (\
+    (0x23 == *(eachline)& 0xff) ||\
+    (0x3b == *(eachline)& 0xff)\
+    )
+
+#define  ESC(__char, __token) ({\
+    char *_scape_character = strchr(__token , __char);\
+    if(_scape_character) *_scape_character=0; \
+    })
+
+#define  OSM_CONFIG_MAX_ALLOW_KEY 0x80
+
+extern char cfg_data[OSM_CONFIG_MAX_ALLOW_KEY][0xff] ;  
+
+typedef struct __osm_cfg_t  osm_cfg_t;  
+extern struct __osm_cfg_t 
+{
+  char _key_attr[0xff]; 
+  char _val_attr[0xff]; 
+} kv_attr[OSM_CONFIG_MAX_ALLOW_KEY] ; 
+ 
+
+/* @fn read_config_file(const char *)
+ * @brief read the config file 
+ * @param  const char *  config filename 
+ * @return int - 0 OK - otherwise error 
+ */
+extern  __inline__ int enhancing_envars (const char * __restrict__ __osm_config_file,
+                                         struct __osm_cfg_t * __restrict__ __kv_attr)  
+{
+  int  fd  =  open(__osm_config_file, O_RDONLY) ; 
+  if(~0 == fd) return  ~0 ; 
+
+  if (dup2(fd , STDIN_FILENO))
+  {
+     close(fd) ; 
+     return ~0 ; 
+  }
+ 
+  int items =0 ; 
+  char eachline[0xff]={0}; 
+  int  index = 0 ;  
+  while((void *)0 != fgets( eachline, 0xff , stdin )) 
+  { 
+    //!NOTICE :Empty line  and comment lines are ignored # ; 
+    if (IS_EMPTY(eachline) ||  IS_COMMENT(eachline)) continue ;  
+     
+    int index = 0,
+       scan_current_line = 1 ; 
+
+    char *token = (void *) 0 , 
+         *current_line = eachline ,
+         *sep   = __assign_symbole ; 
+
+    while ((void*)0  !=  ( token =strtok(current_line,  sep))) 
+    {
+       if(scan_current_line == 1 ) 
+       {
+         scan_current_line^=1 ; 
+         current_line = (void *)0 ;  
+         strcpy((__kv_attr+index)->_key_attr , token) ; 
+       }else 
+       {
+         ESC(0xa,  token) ; 
+         strcpy((__kv_attr+index)->_val_attr , token);
+         setenv((__kv_attr+index)->_key_attr,  (__kv_attr+index)->_val_attr, SHOULD_BE_OVERIDED /*?*/); 
+         index=-~index ; 
+       }
+       
+    }
+    items=-~items ; 
+  }
+
+  close(fd) ; 
+  return items  ;  
+}
+
+#endif 

--- a/src/osmanager.c
+++ b/src/osmanager.c
@@ -1,0 +1,289 @@
+/* @file  osmanager.c 
+ * @brief handle osm process 
+ * @copyright(c) 2025  AGPL-3.0 License -  Umar Ba <jUmarB@protonmail.com> github.com/Jukoo  
+ */ 
+
+#define _GNU_SOURCE
+#include <stdlib.h> 
+#include <stdio.h> 
+#include <string.h> 
+#include <sys/types.h> 
+#include <sys/wait.h> 
+#include <unistd.h> 
+#include <signal.h> 
+#include <stdarg.h> 
+#include <errno.h>
+#include <err.h> 
+#include <time.h> 
+
+#include "config_parser.h"
+#include "osminitdb.h"
+
+struct __osm_cfg_t kv_attr[OSM_CONFIG_MAX_ALLOW_KEY] = {0} ; 
+
+#define CFG_FILE "/etc/osm/osmconf.cfg"
+
+#define  __OSM_MAGIC_CODE {0x6f,0x73,0x6d,0x00}
+#define  __osm_argument_vector(__ident , __size) \
+  char *__ident[__size] = {(char[]) __OSM_MAGIC_CODE} 
+
+/*
+ * The NO_BLOCKING_MODE allow the osm  manager  to do some 
+ * other tasks in paralel while the osm programme  running  
+ *  By default is disabled  but  it can be enable by setting 1  
+ */
+
+#if  defined(NO_BLOCKING_MODE) && NO_BLOCKING_MODE > 0  
+# define  WPID_OPT WNOHANG|WUNTRACED 
+# define  atomic_t   sig_atomic_t  
+#else 
+# define  WPID_OPT  0 
+# define   atomic_t  int 
+#endif 
+
+struct __osmargs_vector{
+  char args[10][100] ; 
+  int argn;  
+} argshandler={{0},0};  
+
+#define  __arghsprintf(...)  \
+  sprintf( *(argshandler.args+argshandler.argn),__VA_ARGS__ ) 
+
+typedef struct  sigaction  sigact_t ; 
+#define  __nptr (void *) 0x00   
+
+sigact_t sa ;  
+atomic_t status = ~0;   
+
+//!  sleep function but in millisec 
+void msleep(int __millis)  ;
+
+/* @fn osm_manager(void) 
+ * @brief the osm handler funtion 
+ * */
+int  osm_manager(void) ;
+
+/* @fn osm_sigcatch (int) 
+ * @brief  catch the signal registred in osm_multsigcatch  
+ * @param int       -- the signal number 
+ * @return atomic_t -- the signal status  
+ * */
+atomic_t   osm_sigcatch(int __signal);  
+
+/* @fn osm_sighandler(atomic_t) 
+ * @brief determine what type of signal is delivred  
+ * @param atomic_t  --  signal status 
+ * @return int      --  signal status 
+ */
+int  osm_sighandler(atomic_t  __atomic_signal_code)  ; 
+
+/* @fn osm_multsigcatch(int  , ... ) 
+ * @brief  allow to specify more than one signal to  handler 
+ *         it's automaticly passed to sigaction  handler 
+ * @param int  -- how many signal 
+ * @param variadic arguments  1..to.. N signal number 
+ * */
+void osm_multsigcatch(int __nsig, ...) ; 
+
+/* @fn argsfmt_builder(char *const , ... )
+ * @brief build argument using  string formating like printf function  
+ * @param  char *const  --- string formating e.g  "string  formation  %i", 10 ...  
+ *         only  the indicator after the '%' is placed as argument  the reste is ignored 
+ *         but   very usefull as commentary  
+ * @param variadic arguments  --- the argument value 
+ *  
+ */
+void argsfmt_builder(char * const __fmt , ...) ; 
+
+
+/* @fn argsentry( char (*)[100] , char *[100] ) 
+ * @brief  transform the arguments array to  array of pointer 
+ *         Require by execvp function the array of pointer must be end with null 
+ * @param  char (*)[100] --  argument from argsfmt_builder 
+ * @param  char *[100]   --  the output  
+ * */
+void argsentry(char  (*__osmargs)[100]  , char  *__args[100]) ; 
+
+
+/* @fn enhancing_environment(struct  __osm_cfg_t []   ,  int) 
+ * @brief  enhancing the environment variables by adding the builted in and 
+ *         the variables that come from the configuration file 
+ * @param  struct __osm_cfg_t[]  - array of structure __osm_cfg_t  list of key=value 
+ * @param  int                   - how many environment variable found on configfile  
+ * */
+void enhancing_environment(struct  __osm_cfg_t * __restrict__ __kv_attr ,  int __how_many_envar_found) ;  
+
+int main(int ac, char **av , char**env) 
+{
+
+  int  pstatus = EXIT_SUCCESS ; 
+  //!Disable buffering on stdout for quick log 
+  (void) setvbuf(stdout ,  __nptr ,  _IONBF , 0) ;
+
+  //!NOTICE: Load the configuration file and dope the environement variable   
+  int  __attribute__((unused)) how_many_envar_found = enhancing_envars(CFG_FILE, kv_attr);  
+
+  //!NOTICE: initialize the database 
+  char * db_file  =  getenv("DB_FILE") ;
+  if (init_db(db_file)) 
+  {
+     pstatus =  EXIT_FAILURE ; 
+     goto __eplg ;
+  }
+  /* !NOTICE  : Register signal action   for the handler */
+  *(void**) &sa.sa_handler= osm_sigcatch ; 
+  osm_multsigcatch(4, SIGTERM , SIGCHLD, SIGKILL , SIGINT);  
+  
+  pid_t  osm_spawn = fork() ; 
+  if (~0 == osm_spawn) 
+  {
+     pstatus = EXIT_FAILURE ; 
+     goto __eplg ; 
+  }
+
+  if(0 == osm_spawn) 
+  {
+    __osm_argument_vector(args_v , 100) ; 
+    argsfmt_builder("Get the pid of the programme  %i", getpid()) ; 
+    char pid[10]={0}; 
+    sprintf(pid , "%i", getpid()); 
+    setenv("OSM_PID" ,  pid, 0 ) ;
+    argsentry(argshandler.args ,  args_v) ;  
+    if (execvp(*(args_v) , args_v)) 
+    {
+       errx(errno, "having trouble to lauch osm application %s", strerror(*__errno_location())) ; 
+       exit(EXIT_FAILURE) ; 
+    }else  
+    return status   ;  
+  }else
+  {
+    osm_sighandler(status) ;  
+    pstatus = osm_manager(); 
+  }
+
+__eplg: 
+  return pstatus ;
+} 
+
+
+atomic_t  osm_sigcatch( int signal ) 
+{  
+ 
+  waitpid(~0,  &status, WPID_OPT)  ;  
+  return status ;
+}
+
+int osm_manager(void) 
+{
+  int  how=0  ; 
+#if  NO_BLOCKING_MODE
+  /*  NOTICE : If you want to perform some other tasks in background  at the same time 
+   *  while the osm programme running  you can put it in the  loop
+   */
+  int  proceed = 1 ;  
+  while(proceed)
+  { 
+    if(status>=0) 
+    { 
+      osm_sighandler(status) ; 
+      proceed^=1 ;  
+    } 
+      
+    //! NOTICE : uncomment this code bellow to see how osm manager keep running in background  
+    //msleep(1000); 
+    //printf("."); 
+   
+  } 
+  
+  how = 0 ; 
+
+#else 
+  waitpid(~0 , &status ,  WPID_OPT) ;
+  //msleep(100); 
+  how= osm_sighandler(status) ;  
+#endif 
+    return how ; 
+} 
+
+int  osm_sighandler(atomic_t  sigatom) 
+{  
+ 
+  if(WIFEXITED(sigatom)) 
+  {
+    return WEXITSTATUS(sigatom) ; 
+  }
+  
+  if(WIFSIGNALED(sigatom))
+  {
+    return  WSTOPSIG(sigatom) ;  
+  }
+
+  if(WIFSTOPPED(sigatom)) 
+  {
+    return WSTOPSIG(sigatom) ; 
+  }
+  
+  return ~0 ; 
+}
+
+void osm_multsigcatch(int nsigs ,  ...) 
+{
+   va_list ap ; 
+   va_start(ap , nsigs) ; 
+   
+   int nsig= ~0 ; 
+   while(++nsig <  nsigs)
+   {
+     int signalnumber =  va_arg(ap , int) ; 
+     sigaction(signalnumber ,  &sa , __nptr); 
+   }
+   va_end(ap);  
+}
+
+void argsfmt_builder (char * const fmt , ...) 
+{
+  va_list ap ;
+  va_start(ap, fmt) ; 
+  int i  = 0 ;  
+  while ( *(fmt+i) !=0  ) 
+  {  
+    if( (*(fmt+i) & 0xff) == 0x25)  
+    {
+       char c =  *(fmt+(i+1))  ;  
+       switch(c) 
+       {
+         case 'i':
+         case 'd': 
+           __arghsprintf("%i" ,(int) va_arg(ap,int)) ; 
+           break ; 
+         case 's':
+           __arghsprintf("%s" , va_arg(ap,char *)) ; 
+           break; 
+       }
+       argshandler.argn=-~argshandler.argn; 
+    }
+    i=-~i ; 
+  }
+
+
+  va_end(ap) ; 
+}
+void argsentry(char (*osmargs)[100]  , char  *args[100])  
+{
+   int  i = ~0 ; 
+   while(++i < argshandler.argn ) 
+     *(args+i+1) =   *(osmargs+i) ; 
+
+   *(args+i+1) = __nptr ; 
+}
+
+
+void msleep(int millisec) 
+{
+  struct  timespec ts = { 
+    .tv_sec  = ( millisec  / 1000 ) , 
+    .tv_nsec = (millisec  % 10000) / 100000000UL 
+  };
+  
+  while((clock_nanosleep(CLOCK_REALTIME, 0  , &ts  , __nptr)) !=0) ; 
+}

--- a/src/osminitdb.h
+++ b/src/osminitdb.h
@@ -1,0 +1,76 @@
+/* @file osminitdb.h 
+ * @brief initial  database  
+ * @copyright(c) 2025  AGPL-3.0 License -  Umar Ba <jUmarB@protonmail.com> github.com/Jukoo  
+ */
+
+#if !defined(__OSM_DB_H) 
+#define  __OSM_DB_H 
+ 
+#include <sqlite3.h> 
+#include <stdio.h> 
+#include <err.h> 
+
+//!TODO :  Should be moved outside not hardcoded  in source file 
+#define  SQL_CREATE_TABLE \
+  "CREATE TABLE IF NOT EXISTS usage_history ("\
+      "id INTEGER PRIMARY KEY AUTOINCREMENT,"\
+      "timestamp DATETIME NOT NULL,"\
+      "cpu_usage REAL NOT NULL,"\
+      "ram_usage REAL NOT NULL,"\
+      "disk_usage REAL NOT NULL)"
+
+
+#define hdl_err(error_code , jmp_lablel, fcall , ...)\
+  do {warn(#fcall __VA_ARGS__);goto jmp_lablel;}while(0) 
+
+typedef int (*__user_sqlite3_cb) (void * ,  int , char** , char ** )   ; 
+#define  __user_sqlite3_cb  user_callback  
+
+char  *errmsg = (void *)0  ; 
+
+/* @fn __initial_record(sqlite3 * ,  const char *) 
+ * @bref make a record to file data base with sql statement 
+ * @param sqlite3 *     -  instance  
+ * @param const char *  -  SQL statement to execute  
+ * @return int   SQLITE_OK(ok) otherwise failure 
+ **/
+extern __inline__  int __initial_record(sqlite3 *  __sql3 ,  const char *__restrict__ __SQL_STATEMENT)   
+{ 
+  int status = sqlite3_exec(__sql3, __SQL_STATEMENT , (void*)0 , (void*)0 , &errmsg ); 
+  
+  sqlite3_free(errmsg) ; 
+  return status ; 
+}
+/* @fn init_db(const char *) 
+ * @brief  initialize the database the file db will be created if not exists automaticly 
+ * @param  const char *  - database file name 
+ * @return int  status   - SQLITE_OK (ok) otherwise failure 
+ */
+extern  __inline__ int  init_db(const char * __restrict__ __database_filename) 
+{
+  int init_db_status= SQLITE_OK ;  
+  sqlite3 * lightquery  ;  
+   
+   if(SQLITE_OK != (sqlite3_open_v2(__database_filename , &lightquery ,  SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, (void *)0 )))  
+   { 
+     hdl_err(pstatus =~0 , __init_db_out ,init_db,"Fail to  open database %s", sqlite3_errmsg(lightquery)) ; 
+   } 
+
+   if (SQLITE_OK != __initial_record(lightquery  ,SQL_CREATE_TABLE)) 
+   { 
+     sqlite3_close(lightquery) ; 
+     hdl_err(pstatus =~0 , __init_db_out ,__initial_record, "Fail to  put initial record  %s", sqlite3_errmsg(lightquery)) ; 
+   }
+
+
+  sqlite3_close(lightquery) ; 
+__init_db_out:
+   return  init_db_status; 
+
+}
+
+
+
+
+
+#endif //! __OSM_DB_H 


### PR DESCRIPTION

Salut, 
Ceci est le résultat de mon expérimentation sur la gestion et la communication des processus de base sur  système Unix.
 
**TL;DR** J'ai fait en sorte que le osm s'exécute à partir d'un processus manager  qui ajoute une couche d'isolation supplementaire.

Le gestionnaire de processus s'appelle « osmon » et en plus de l'isolation, il s'occupe de toute l'initialisation dont osm a besoin (comme la base de données, l'initialisation des variables d'environnement à partir d'un fichier de configuration dédié, mais aussi la gestion des signaux et la possibilité de transmettre des arguments à osm qui peuvent être mis en cache par sys.argv(python). 

Un autre avantage est que le gestionnaire peut faire d'autres choses en parallèle tout en exécutant osm.
Cette fonctionnalité est déjà disponible pour une utilisation future, il suffit de l'activer au moment de la compilation. 

Il a deux modes généraux de fonctionnement : le mode bloquant et le mode non bloquant. 
le mode bloquant : il gère uniquement l'osm (initialisation, signaux et transmission de paramètres à l'osm) 

le mode non bloquant gère l'osm avec les mêmes avantages que le mode bloquant, et peut faire d'autres choses en parallèle, comme mentionné ci-dessus.
cette option n'est pas activée par défaut mais peut l'être. 
par exemple pour la communication en temps réel avec l'osm (ce qui est une possibilité concevable). 
en fonction des besoins futurs.

- pour initialiser la base de données, j'utilise l'interface de base **sqlite3** nativement présente. 

- pour initialiser les variables d'environnement, je procède par lecture d'un fichier de configuration

- puis il ajoute les variables d'environnement pour que l'osm puisse en profiter pleinement 

> J'ai un peu modifié le code d'osm pour que ces variables d'environnement soient directement utilisable dans le code avec le bon typage.  
Et j'ai également ajouté son pid (le pid de l'osm en question) comme information dans les messages de log, au cas où l'utilisateur voudrait faire quelque chose avec lui, comme le tuer avec son pid (kill pid) etc ...  

Le shell du conteneur est également formaté plus explicitement avec des couleurs, voir context/profile.  visible en mode interactif 

```bash 
$ docker run -it  -v /proc:/host_proc  <image> ash 
$ osmon 
```

La structure des dossiers du projet a été légèrement modifiée pour éviter de polluer la structure existante.  
Cependant, de nouveaux dossiers ont été ajoutés : 

-> config : pour la configuration   
-> src : Fichiers sources en C pour osmon (le gestionnaire)
-> context : pour la personnalisation du conteneur  
le fichier de construction du  osm manager est  basé sur meson
-> meson.build : contient la recette pour construire les fichiers sources  

pour la compilation :
```bash 
meson setup build  
meson compile -C build  
meson install -C build   
```  
** Ces commandes sont exécutées lors de la construction de l'image ( à ne pas faire sur votre hôte ) 

# Note Pour la config: 
Il a peut agir en deux mode **non-override** ou **override**.

Pour le **"non-override"** : la configuration par défaut de docker compose des valeurs qui ne seront pas écrasées.
Le mode **"override"** est que la configuration prend le dessus. (peut être activé à la compilation, mais je pense que je le mettrai dans la configuration)
peut être activé à la volée)

Un point de montage entre _/etc/osm/_ et l'hôte de l'utilisateur  pour qu'il puisse éditer directement à partir de ce fichier.
Osmon prendra le relais pour initialiser l'environnement au  lancement du osm  

**NB :** 
     Il est recommandé de l'utiliser uniquement avec docker 
     pour cette version  l'osm peut pas tourner en dur directement sur le host ce qui casse le **Developer guide section**.
     Mais cela va etre corriger sur la prochaine version du proposal.
     Par contre l'enviroment de Dev  peut etre monte sur le docker en mode interaction 
     `$ docker run -ti  -v./:./app  -v /proc:./host_proc  <image> ash ` 

osm -> osm.py 
osmon -> binaire  du manager disponible globalement sur le container  

Ramadan Moubarack. 
Love Computers @ all Level
From  Sénégal.

Je reste disponible pour les feedback ou des améliorations futures.


- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change ( Developer Guide Section ) 
- [x] This change requires a documentation update


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
